### PR TITLE
Redirect to public job page

### DIFF
--- a/app/controllers/users/jobs_controller.rb
+++ b/app/controllers/users/jobs_controller.rb
@@ -2,7 +2,8 @@
 
 module Users
   class JobsController < UserController
-    before_action :set_job, only: %i[show edit update destroy]
+    before_action :set_job, only: %i[edit update destroy]
+    skip_before_action :authenticate_user!, only: [:show]
 
     def index
       @jobs = jobs.page(page).per(per_page)
@@ -10,6 +11,16 @@ module Users
     end
 
     def show
+      @job = Job.find(params[:id])
+
+      unless current_user
+        return redirect_to(job_url(@job))
+      end
+
+      unless current_user.admin? || @job.belongs_to?(current_user)
+        return redirect_to(job_url(@job))
+      end
+
       respond_with(:user, @job)
     end
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -18,6 +18,10 @@ class Job < ApplicationRecord
     "#{id}-#{title.parameterize}"
   end
 
+  def belongs_to?(user)
+    user_id == user.id
+  end
+
   # form helper
   attr_writer :state_id
 

--- a/spec/controllers/users/jobs_controller_spec.rb
+++ b/spec/controllers/users/jobs_controller_spec.rb
@@ -70,18 +70,38 @@ describe Users::JobsController, type: :controller do
   end
 
   describe '#show' do
-    it_requires_authentication { get :show, params: { id: 1 } }
-
     with_valid_user_or_admin do
       let(:job) { Job.make!(user: user) }
 
       it 'assigns job to @job' do
-        get :show, params: { id: job.id }
+        get :show, params: { id: job.to_param }
         expect(assigns(:job)).to eq(job)
       end
 
-      it_responds_with_success { get :show, params: { id: job.id } }
-      it_renders_template(:show) { get :show, params: { id: job.id } }
+      it_responds_with_success { get :show, params: { id: job.to_param } }
+      it_renders_template(:show) { get :show, params: { id: job.to_param } }
+    end
+
+    context 'when user is not logged in' do
+      it 'redirects to the public job page' do
+        job = Job.make!(user: user)
+
+        get :show, params: { id: job.to_param }
+
+        expect(response).to redirect_to(job_url(job))
+      end
+    end
+
+    context 'when user is logged in but does not own the job' do
+      it 'redirects to the public job page' do
+        sign_in(User.make!)
+
+        job = Job.make!(user: user)
+
+        get :show, params: { id: job.to_param }
+
+        expect(response).to redirect_to(job_url(job))
+      end
     end
   end
 

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Job do
 
   describe '.open' do
     it 'returns only the enabled records' do
-      open   = described_class.make! open: true
-      closed = described_class.make! open: false
+      open = described_class.make! open: true
+      described_class.make! open: false
 
       expect(described_class.open).to eq([open])
     end
@@ -39,6 +39,20 @@ RSpec.describe Job do
       expect do
         subject.state_id = '2'
       end.to change { subject.state_id }.to(2)
+    end
+  end
+
+  describe '#belongs_to?' do
+    let(:owner) { User.new(id: 1) }
+    let(:other_user) { User.new(id: 2) }
+    let(:job) { Job.new(user: owner) }
+
+    it 'returns true when user owns job' do
+      expect(job.belongs_to?(owner)).to be(true)
+    end
+
+    it 'returns true when user owns job' do
+      expect(job.belongs_to?(other_user)).to be(false)
     end
   end
 end


### PR DESCRIPTION
* Fix #45

When I share the wrong link I.E.
  http://rubyjobsbrazil.com.br/profile/jobs/253-foo-bar
And logged out users cannot access this page
  I want them to be redirected to http://rubyjobsbrazil.com.br/jobs/253-foo-bar